### PR TITLE
Feature - Attach comment at time of upload

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -56,11 +56,7 @@ uploadFile(
   Cli.message,
   Cli.lines,
   Cli.tail
-).then((file) => {
-  if (Cli.message) {
-    return attachCommentToFile(getAccessToken(), file.id, Cli.message);
-  }
-}).finally(() => {
+).finally(() => {
   spinner.stop(true);
 }).then(() => {
   Print.success('Upload complete!');

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ import pkg from '../package.json';
 import chalk from 'chalk';
 import invariant from './invariant';
 import * as Print from './print';
-import {uploadFile, attachCommentToFile} from './client';
+import {uploadFile} from './client';
 import {Spinner} from 'cli-spinner';
 
 const lineParser = lines => lines.split('..').map(Number);

--- a/src/client.js
+++ b/src/client.js
@@ -27,15 +27,16 @@ const toChannelString = (channel, user) => {
   return targets.join(',');
 }
 
-const fileUploadPayload = (channels, filename, file, token) => ({
+const fileUploadPayload = (channels, filename, file, message, token) => ({
   content: file,
   title: filename,
+  initial_comment: message,
   filename,
   channels,
   token
 });
 
-export function uploadFile (token, filename, channel, user, message, lines, tail) {
+export function uploadFile (token, filename, channel, user, message = '', lines, tail) {
   return readFile(filename).then(file => {
     if (lines && lines.length > 1) {
       invariant(
@@ -53,6 +54,7 @@ export function uploadFile (token, filename, channel, user, message, lines, tail
       toChannelString(channel, user),
       filename,
       file,
+      message,
       token
     );
 
@@ -64,19 +66,4 @@ export function uploadFile (token, filename, channel, user, message, lines, tail
     .then(rpcResponseHandler)
     .then(response => response.file)
   });
-}
-
-export function attachCommentToFile (token, file, comment, onComplete = () => {}) {
-  var formData = {
-    token,
-    file,
-    comment
-  };
-  request.post({
-    url: `${BASE_URL}/files.comments.add`,
-    formData
-  })
-  .then(JSON.parse)
-  .then(rpcResponseHandler)
-  .then(response => response.comment);
 }


### PR DESCRIPTION
Uses `initial_comment` param instead of making a follow on request to assign the file comment. Saves precious milliseconds in the process.

Docs: https://api.slack.com/methods/files.upload
